### PR TITLE
fix: route shard saves through durable_write for crash safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Shard rotation, `save()`, and `compact()` bypass the durable write path — all three called
+    `usearch.index.Index.save(path)` directly (no temp file, no fsync, no atomic rename). All
+    writable shard saves now go through buffer serialization + `durable_write`
+    ([#26](https://github.com/iscc/iscc-usearch/issues/26))
+
+### Changed
+
+- Persistence ordering during `save()` and shard rotation is now bloom → shard → tombstones.
+    Tombstone removals only become visible after the shard data they depend on is durable,
+    preventing previously deleted keys from reappearing after a crash
+- Missing or corrupt bloom filter files are automatically rebuilt from shard keys on load
+    instead of silently disabling bloom lookups
+
 ## [0.7.0] - 2026-05-06
 
 ### Added

--- a/docs/explanation/sharding-design.md
+++ b/docs/explanation/sharding-design.md
@@ -38,11 +38,14 @@ stateDiagram-v2
 
 When the active shard exceeds the configured `shard_size`, it is:
 
-1. Saved to disk as `shard_NNN.usearch`.
-1. Reopened in view mode (memory-mapped, read-only).
+1. Bloom filter and shard file saved durably (buffer → fdatasync → atomic rename).
+1. Tombstones persisted after the shard is durable.
+1. Shard reopened in view mode (memory-mapped, read-only).
 1. Replaced by a fresh, empty active shard.
 
-This rotation resets the HNSW insert curve and keeps throughput consistent.
+This rotation resets the HNSW insert curve and keeps throughput consistent. The
+bloom → shard → tombstones ordering ensures that tombstone removals only become visible after
+the shard data they depend on is safely on disk.
 
 ## Bloom filter integration
 
@@ -67,7 +70,8 @@ The bloom filter is:
 
 - Persisted alongside shard files as `bloom.isbf`.
 - Updated automatically when vectors are added.
-- Rebuilt via `rebuild_bloom()` if corrupted or missing.
+- Rebuilt automatically on load if the file is missing or corrupt.
+- Rebuilt manually via `rebuild_bloom()` if needed.
 
 ## Search fan-out
 

--- a/docs/howto/persistence.md
+++ b/docs/howto/persistence.md
@@ -18,7 +18,7 @@ flushes to stable storage with `fdatasync`, then atomically renames the temp fil
 The result is both atomic (no partial files on crash) and durable (data survives power loss).
 
 Sharded indexes use the same durable file-save path for `.usearch` shard files. `ShardedIndex.save()`
-does not accept a path argument; it saves the active shard, bloom filter, and tombstones into the
+does not accept a path argument; it saves the bloom filter, active shard, and tombstones into the
 directory configured at construction time:
 
 ```python
@@ -27,6 +27,30 @@ index.save()
 
 Long-running sharded saves log start and completion messages at `INFO`, including the shard name
 and vector count.
+
+### Persistence ordering
+
+Sharded saves (both explicit `save()` and automatic shard rotation) persist files in this order:
+
+1. **Bloom filter** (`bloom.isbf`) — extra entries are harmless false positives.
+1. **Shard file** (`shard_NNN.usearch`) — the actual vector data.
+1. **Tombstones** (`tombstones.npy`) — tombstone removals only become visible after the shard
+    data they depend on is durable.
+
+This ordering prevents previously deleted keys from reappearing after a crash. If the process
+dies after writing the shard but before updating tombstones, the stale tombstone entries just
+hide the key from view shards — but the key is safely in the shard.
+
+### Crash recovery
+
+On load, `ShardedIndex` applies defensive recovery:
+
+- **Stale temp files** (`*.usearch.tmp`, `*.isbf.tmp`, `*.npy.tmp`) from interrupted durable
+    writes are deleted automatically.
+- **Missing or corrupt bloom filter** — rebuilt from all shard keys with a logged warning.
+    The bloom is a derived index, not a source of truth.
+- **Missing tombstone file** — assumed no tombstones. Previously tombstoned keys may reappear
+    from view shards.
 
 ## Load an index from disk
 

--- a/docs/reference/for-coding-agents.md
+++ b/docs/reference/for-coding-agents.md
@@ -158,6 +158,7 @@ semantics are required.
 - `contains()` / `get()` / `remove()` use bloom for fast rejection of non-existent keys.
 - False positives are expected (probabilistic). False negatives do not occur.
 - `rebuild_bloom()` creates a fresh filter from all existing keys.
+- Automatically rebuilt on load if the file is missing or corrupt (writable indexes only).
 - `compact()` calls `rebuild_bloom()` internally.
 - Bloom filter file: `bloom.isbf` in the shard directory.
 - Always loaded from disk if file exists, regardless of `_use_bloom` setting.
@@ -167,7 +168,7 @@ semantics are required.
 ```
 remove(key) → key added to _tombstones (in-memory set)
     ↓
-save() → _tombstones persisted as tombstones.npy
+save() → bloom persisted, then shard, then _tombstones as tombstones.npy
     ↓
 compact() → view shards rebuilt excluding tombstoned entries
     ↓
@@ -177,25 +178,27 @@ _tombstones.clear(), tombstones.npy deleted
 - `_needs_compact` flag: set when `add()` clears a tombstone (creating cross-shard duplicates).
 - `tombstones.npy` file existence signals `_needs_compact=True` on next load.
 - Tombstones are never written to bloom filter — bloom has no "remove" operation.
+- Tombstones are persisted **after** shard data so that tombstone removals only become
+    visible once the shard they depend on is durable.
 
 ---
 
 ## Side effects catalog
 
-| Method            | Disk writes                                                 | `_dirty`                | `_tombstones`              | Bloom update         | Shard rotation         |
-| ----------------- | ----------------------------------------------------------- | ----------------------- | -------------------------- | -------------------- | ---------------------- |
-| `add()`           | None (until rotation)                                       | `+= count_added`        | Clears matching tombstones | `add_batch()`        | Yes (if size exceeded) |
-| `remove()`        | None                                                        | `+= N` (existing only)  | Adds view-shard keys       | None                 | No                     |
-| `upsert()`        | None                                                        | Via remove + add        | Via remove + add           | Via add              | Via add                |
-| `add_once()`      | None                                                        | Via add (new keys only) | None                       | Via add              | Via add                |
-| `save()`          | `.usearch`, `bloom.isbf`, `tombstones.npy`                  | Reset to 0              | Persisted                  | Persisted            | No                     |
-| `load()`          | None                                                        | Reset to 0              | Loaded from `.npy`         | Loaded from `.isbf`  | No                     |
-| `view()`          | None                                                        | Reset to 0              | N/A (NphdIndex)            | N/A                  | No                     |
-| `reset()`         | None                                                        | Reset to 0              | Cleared                    | Cleared              | No                     |
-| `compact()`       | Rebuilds `.usearch`, `bloom.isbf`, deletes `tombstones.npy` | Reset to 0              | Cleared                    | Rebuilt              | No                     |
-| `search()`        | None                                                        | No change               | No change                  | None                 | No                     |
-| `get()`           | None                                                        | No change               | No change                  | None                 | No                     |
-| `rebuild_bloom()` | `bloom.isbf` (if `save=True`)                               | No change               | No change                  | Rebuilt from scratch | No                     |
+| Method            | Disk writes                                                             | `_dirty`                | `_tombstones`              | Bloom update         | Shard rotation         |
+| ----------------- | ----------------------------------------------------------------------- | ----------------------- | -------------------------- | -------------------- | ---------------------- |
+| `add()`           | None (until rotation; rotation durably writes bloom, shard, tombstones) | `+= count_added`        | Clears matching tombstones | `add_batch()`        | Yes (if size exceeded) |
+| `remove()`        | None                                                                    | `+= N` (existing only)  | Adds view-shard keys       | None                 | No                     |
+| `upsert()`        | None                                                                    | Via remove + add        | Via remove + add           | Via add              | Via add                |
+| `add_once()`      | None                                                                    | Via add (new keys only) | None                       | Via add              | Via add                |
+| `save()`          | `.usearch`, `bloom.isbf`, `tombstones.npy`                              | Reset to 0              | Persisted                  | Persisted            | No                     |
+| `load()`          | None                                                                    | Reset to 0              | Loaded from `.npy`         | Loaded from `.isbf`  | No                     |
+| `view()`          | None                                                                    | Reset to 0              | N/A (NphdIndex)            | N/A                  | No                     |
+| `reset()`         | None                                                                    | Reset to 0              | Cleared                    | Cleared              | No                     |
+| `compact()`       | Rebuilds `.usearch`, `bloom.isbf`, deletes `tombstones.npy`             | Reset to 0              | Cleared                    | Rebuilt              | No                     |
+| `search()`        | None                                                                    | No change               | No change                  | None                 | No                     |
+| `get()`           | None                                                                    | No change               | No change                  | None                 | No                     |
+| `rebuild_bloom()` | `bloom.isbf` (if `save=True`)                                           | No change               | No change                  | Rebuilt from scratch | No                     |
 
 ---
 

--- a/src/iscc_usearch/sharded.py
+++ b/src/iscc_usearch/sharded.py
@@ -27,7 +27,7 @@ from usearch.index import (
 )
 
 from iscc_usearch.bloom import ScalableBloomFilter
-from iscc_usearch.utils import atomic_write, timer
+from iscc_usearch.utils import atomic_write, durable_write, timer
 
 __all__ = ["ShardedIndex", "ShardedIndex128", "ShardedIndexedKeys", "ShardedIndexedVectors"]
 
@@ -1085,42 +1085,30 @@ class ShardedIndex:
                 "ShardedIndex.save() does not accept a path argument. "
                 "Files are saved to the directory specified at construction time."
             )
-        # Save bloom filter if it exists
-        if self._bloom is not None:
-            bloom_path = self._path / BLOOM_FILENAME
-            with timer("ShardedIndex save bloom filter", level="INFO"):
-                self._bloom.save(bloom_path)
+        # Persist bloom → shard → tombstones (safe ordering for crash recovery:
+        # shard must be durable before tombstone removals become visible)
+        self._persist_bloom()
 
-        # Save tombstones (also serves as the _needs_compact persistence flag:
-        # file exists → filtering needed on next load, even if tombstones are empty)
-        tombstone_path = self._path / TOMBSTONE_FILENAME
-        if self._tombstones or self._needs_compact:
-            with atomic_write(tombstone_path) as tmp:
-                with open(tmp, "wb") as f:
-                    arr = np.array(sorted(self._tombstones), dtype=self._key_dtype)
-                    np.save(f, arr)
-        elif tombstone_path.exists():
-            tombstone_path.unlink()
+        if self._active_shard is not None and len(self._active_shard) > 0:
+            shard_path = self._get_active_shard_path()
+            active_count = len(self._active_shard)
+            with timer(
+                f"ShardedIndex save {shard_path.name} ({active_count:,} vectors)",
+                log_start=True,
+                level="INFO",
+            ):
+                data = self._active_shard.save(progress=progress)
+                durable_write(data, shard_path)
+            self._active_shard_path = shard_path
+            self._invalidate_shard_cache()
 
-        if self._active_shard is None or len(self._active_shard) == 0:
-            self._dirty = 0
-            return
+        self._persist_tombstones()
 
-        shard_path = self._get_active_shard_path()
-        active_count = len(self._active_shard)
-        with timer(
-            f"ShardedIndex save {shard_path.name} ({active_count:,} vectors)",
-            log_start=True,
-            level="INFO",
-        ):
-            self._active_shard.save(str(shard_path), progress=progress)
-        self._active_shard_path = shard_path
-        # Invalidate cache since new shard file may have been created
-        self._invalidate_shard_cache()
         from loguru import logger
 
         num_shards = len(self._discover_shards())
-        logger.info(f"Saved {num_shards} shard(s) to {self._path}")
+        if num_shards:
+            logger.info(f"Saved {num_shards} shard(s) to {self._path}")
         self._dirty = 0
 
     def rebuild_bloom(self, save: bool = True, log_progress: bool = True) -> int:
@@ -1173,11 +1161,8 @@ class ShardedIndex:
         if log_progress:
             logger.info(f"Bloom filter rebuilt with {count:,} keys")
 
-        # Save if requested
         if save:
-            bloom_path = self._path / BLOOM_FILENAME
-            with timer("ShardedIndex save bloom filter"):
-                self._bloom.save(bloom_path)
+            self._persist_bloom()
 
         return count
 
@@ -1272,7 +1257,8 @@ class ShardedIndex:
                 new_shard = self._create_shard()
                 new_shard.add(self._shard_batch_keys(live_keys), live_vectors)
 
-                new_shard.save(str(shard_path))
+                shard_data = new_shard.save()
+                durable_write(shard_data, shard_path)
 
                 viewed = self._restore_shard(shard_path, view=True)
                 if viewed is not None:  # pragma: no branch
@@ -1382,6 +1368,11 @@ class ShardedIndex:
         self._config["expansion_add"] = last_shard.expansion_add
         self._config["expansion_search"] = last_shard.expansion_search
         self._config["multi"] = last_shard.multi
+
+        # Rebuild bloom filter if missing or corrupt but shards exist
+        if self._use_bloom and self._bloom is None and not self._read_only:
+            logger.warning("Bloom filter missing — rebuilding from shard keys")
+            self.rebuild_bloom(save=True)
 
     @staticmethod
     def metadata(path: str | os.PathLike) -> dict | None:
@@ -1798,13 +1789,18 @@ class ShardedIndex:
         in sync with index contents. The _use_bloom flag only controls whether
         to USE the bloom filter for fast rejection in lookups.
 
-        Returns None when no bloom file exists. Call rebuild_bloom() to create
-        a bloom filter for existing indexes that don't have one.
+        Returns None when no bloom file exists or if the file is corrupt.
         """
+        from loguru import logger
+
         bloom_path = self._path / BLOOM_FILENAME
         if bloom_path.exists():
-            with timer("ShardedIndex load bloom filter", level="INFO"):
-                return ScalableBloomFilter.load(bloom_path)
+            try:
+                with timer("ShardedIndex load bloom filter", level="INFO"):
+                    return ScalableBloomFilter.load(bloom_path)
+            except Exception:
+                logger.warning(f"Corrupt bloom filter at {bloom_path} — will rebuild")
+                return None
         return None
 
     def _restore_shard(self, path: Path, view: bool) -> Index | None:
@@ -1873,6 +1869,28 @@ class ShardedIndex:
         else:
             self._adds_until_size_check = 1
 
+    def _persist_bloom(self) -> None:
+        """Save bloom filter to disk if it exists."""
+        if self._bloom is not None:
+            bloom_path = self._path / BLOOM_FILENAME
+            with timer("ShardedIndex save bloom filter", level="INFO"):
+                self._bloom.save(bloom_path)
+
+    def _persist_tombstones(self) -> None:
+        """Save tombstones to disk.
+
+        File presence also serves as the _needs_compact persistence flag:
+        file exists -> filtering needed on next load, even if tombstones are empty.
+        """
+        tombstone_path = self._path / TOMBSTONE_FILENAME
+        if self._tombstones or self._needs_compact:
+            with atomic_write(tombstone_path) as tmp:
+                with open(tmp, "wb") as f:
+                    arr = np.array(sorted(self._tombstones), dtype=self._key_dtype)
+                    np.save(f, arr)
+        elif tombstone_path.exists():
+            tombstone_path.unlink()
+
     def _rotate_shard(self) -> None:
         """Save current shard and create new one."""
         if self._active_shard is None:
@@ -1885,14 +1903,20 @@ class ShardedIndex:
         else:
             shard_path = self._get_shard_path(self._get_next_shard_number())
 
-        # Save current active shard
+        # Persist bloom → shard → tombstones (safe ordering for crash recovery:
+        # shard must be durable before tombstone removals become visible)
+        self._persist_bloom()
+
         active_count = len(self._active_shard)
         with timer(
             f"ShardedIndex rotate {shard_path.name} ({active_count:,} vectors)",
             log_start=True,
             level="INFO",
         ):
-            self._active_shard.save(str(shard_path))
+            data = self._active_shard.save()
+            durable_write(data, shard_path)
+
+        self._persist_tombstones()
         # Clear tracked path since we're creating a new unsaved shard
         self._active_shard_path = None
         # Invalidate cache since new shard file was created

--- a/tests/test_sharded_bloom.py
+++ b/tests/test_sharded_bloom.py
@@ -153,13 +153,8 @@ def test_bloom_loaded_on_load(tmp_path: Path):
     assert not idx2.contains(9999)
 
 
-def test_bloom_missing_file_disables_bloom(tmp_path: Path):
-    """Test that missing bloom file disables bloom in load mode (legacy index).
-
-    This tests the regression where loading a legacy index without a bloom.isbf
-    file would create an empty bloom filter, causing all lookups to return
-    False/None because an empty bloom filter rejects all keys.
-    """
+def test_bloom_missing_file_rebuilds_on_load(tmp_path: Path):
+    """Test that missing bloom file triggers automatic rebuild from shard keys."""
     # Create and save index with bloom filter
     idx = ShardedIndex(ndim=32, path=tmp_path)
     vectors = np.random.rand(10, 32).astype(np.float32)
@@ -167,20 +162,21 @@ def test_bloom_missing_file_disables_bloom(tmp_path: Path):
     idx.add(keys, vectors)
     idx.save()
 
-    # Delete bloom file to simulate legacy index
+    # Delete bloom file to simulate legacy index or crash recovery
     bloom_path = tmp_path / "bloom.isbf"
     bloom_path.unlink()
 
-    # Load in load mode (default) - should work without bloom
+    # Load — bloom should be rebuilt automatically from shard keys
     idx2 = ShardedIndex(ndim=32, path=tmp_path)
-    assert idx2._bloom is None  # Bloom should be disabled, not empty
+    assert idx2._bloom is not None
+    assert idx2._bloom.count == 10
 
-    # Critical: lookups should still work by scanning shards
+    # Lookups work correctly via rebuilt bloom
     assert len(idx2) == 10
-    assert idx2.contains(0)  # Must find existing keys
+    assert idx2.contains(0)
     assert idx2.contains(5)
     assert idx2.contains(9)
-    assert not idx2.contains(999)  # Non-existent key
+    assert not idx2.contains(999)
 
     # get() should also work
     result = idx2.get(5)
@@ -188,6 +184,9 @@ def test_bloom_missing_file_disables_bloom(tmp_path: Path):
 
     result = idx2.get(999)
     assert result is None
+
+    # Bloom file should be persisted after rebuild
+    assert bloom_path.exists()
 
 
 def test_bloom_disabled_index_works_normally(tmp_path: Path):

--- a/tests/test_sharded_durable.py
+++ b/tests/test_sharded_durable.py
@@ -1,0 +1,292 @@
+"""
+Test durable write path for ShardedIndex shard persistence.
+
+Verifies that all writable shard saves go through buffer + durable_write,
+bloom/tombstone ordering is correct, and crash recovery is resilient.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from iscc_usearch.sharded import ShardedIndex
+
+
+def test_save_uses_durable_write(tmp_path):
+    """save() persists the active shard via durable_write, not direct .save(path)."""
+    idx = ShardedIndex(ndim=32, path=tmp_path)
+    idx.add(list(range(5)), np.random.rand(5, 32).astype(np.float32))
+
+    calls = []
+    original_durable_write = __import__("iscc_usearch.utils", fromlist=["durable_write"]).durable_write
+
+    def tracking_durable_write(data, target):
+        calls.append(Path(target).name)
+        return original_durable_write(data, target)
+
+    with patch("iscc_usearch.sharded.durable_write", side_effect=tracking_durable_write):
+        idx.save()
+
+    shard_calls = [c for c in calls if c.endswith(".usearch")]
+    assert len(shard_calls) == 1
+    assert shard_calls[0] == "shard_000.usearch"
+
+
+def test_rotation_uses_durable_write(tmp_path):
+    """_rotate_shard() persists the shard via durable_write."""
+    idx = ShardedIndex(ndim=32, path=tmp_path, shard_size=500)
+
+    calls = []
+    original_durable_write = __import__("iscc_usearch.utils", fromlist=["durable_write"]).durable_write
+
+    def tracking_durable_write(data, target):
+        calls.append(Path(target).name)
+        return original_durable_write(data, target)
+
+    with patch("iscc_usearch.sharded.durable_write", side_effect=tracking_durable_write):
+        for i in range(100):
+            idx.add(i, np.random.rand(32).astype(np.float32))
+
+    shard_calls = [c for c in calls if c.endswith(".usearch")]
+    assert len(shard_calls) >= 1, "At least one shard rotation should use durable_write"
+
+
+def test_compact_uses_durable_write(tmp_path):
+    """compact() persists rebuilt shards via durable_write."""
+    idx = ShardedIndex(ndim=32, path=tmp_path, shard_size=500)
+    for i in range(100):
+        idx.add(i, np.random.rand(32).astype(np.float32))
+    idx.save()
+
+    # Remove some keys to create tombstones
+    idx.remove([0, 1, 2])
+
+    calls = []
+    original_durable_write = __import__("iscc_usearch.utils", fromlist=["durable_write"]).durable_write
+
+    def tracking_durable_write(data, target):
+        calls.append(Path(target).name)
+        return original_durable_write(data, target)
+
+    with patch("iscc_usearch.sharded.durable_write", side_effect=tracking_durable_write):
+        idx.compact()
+
+    shard_calls = [c for c in calls if c.endswith(".usearch")]
+    assert len(shard_calls) >= 1, "compact() should use durable_write for rebuilt shards"
+
+
+def test_original_shard_intact_on_durable_write_failure(tmp_path):
+    """If durable_write fails, the original shard file is not corrupted."""
+    idx = ShardedIndex(ndim=32, path=tmp_path)
+    idx.add(list(range(5)), np.random.rand(5, 32).astype(np.float32))
+    idx.save()
+
+    shard_path = tmp_path / "shard_000.usearch"
+    original_size = shard_path.stat().st_size
+    original_data = shard_path.read_bytes()
+
+    # Add more data, then make save fail
+    idx.add(list(range(10, 15)), np.random.rand(5, 32).astype(np.float32))
+
+    def failing_durable_write(data, target):
+        raise OSError("Simulated write failure")
+
+    with patch("iscc_usearch.sharded.durable_write", side_effect=failing_durable_write):
+        with pytest.raises(OSError, match="Simulated write failure"):
+            idx.save()
+
+    # Original file should be unchanged
+    assert shard_path.stat().st_size == original_size
+    assert shard_path.read_bytes() == original_data
+
+
+def test_rotation_persistence_order(tmp_path):
+    """_rotate_shard() persists bloom → shard → tombstones (shard before tombstones)."""
+    idx = ShardedIndex(ndim=32, path=tmp_path, shard_size=500)
+
+    order = []
+    original_persist_bloom = ShardedIndex._persist_bloom
+    original_persist_tombstones = ShardedIndex._persist_tombstones
+    original_durable_write = __import__("iscc_usearch.utils", fromlist=["durable_write"]).durable_write
+
+    def tracking_bloom(self):
+        order.append("bloom")
+        return original_persist_bloom(self)
+
+    def tracking_tombstones(self):
+        order.append("tombstones")
+        return original_persist_tombstones(self)
+
+    def tracking_durable_write(data, target):
+        if str(target).endswith(".usearch"):
+            order.append("shard")
+        return original_durable_write(data, target)
+
+    with (
+        patch.object(ShardedIndex, "_persist_bloom", tracking_bloom),
+        patch.object(ShardedIndex, "_persist_tombstones", tracking_tombstones),
+        patch("iscc_usearch.sharded.durable_write", side_effect=tracking_durable_write),
+    ):
+        for i in range(100):
+            idx.add(i, np.random.rand(32).astype(np.float32))
+
+    bloom_indices = [i for i, x in enumerate(order) if x == "bloom"]
+    shard_indices = [i for i, x in enumerate(order) if x == "shard"]
+    tombstone_indices = [i for i, x in enumerate(order) if x == "tombstones"]
+    assert bloom_indices, "Bloom should be persisted during rotation"
+    assert shard_indices, "Shard should be persisted during rotation"
+    assert tombstone_indices, "Tombstones should be persisted during rotation"
+    for b, s in zip(bloom_indices, shard_indices):
+        assert b < s, f"Bloom (index {b}) must precede shard (index {s})"
+    for s, t in zip(shard_indices, tombstone_indices):
+        assert s < t, f"Shard (index {s}) must precede tombstones (index {t})"
+
+
+def test_bloom_rebuild_on_corrupt_file(tmp_path):
+    """Corrupt bloom file triggers rebuild from shard keys."""
+    idx = ShardedIndex(ndim=32, path=tmp_path)
+    idx.add(list(range(10)), np.random.rand(10, 32).astype(np.float32))
+    idx.save()
+
+    # Corrupt the bloom file
+    bloom_path = tmp_path / "bloom.isbf"
+    bloom_path.write_bytes(b"corrupt data")
+
+    # Reload — should rebuild bloom without error
+    idx2 = ShardedIndex(ndim=32, path=tmp_path)
+    assert idx2._bloom is not None
+    assert idx2._bloom.count == 10
+    assert idx2.contains(0)
+    assert idx2.contains(9)
+    assert not idx2.contains(999)
+
+
+def test_tombstone_file_missing_on_reload(tmp_path):
+    """Missing tombstone file on reload doesn't crash — tombstoned keys reappear."""
+    idx = ShardedIndex(ndim=32, path=tmp_path, shard_size=500)
+    for i in range(100):
+        idx.add(i, np.random.rand(32).astype(np.float32))
+    idx.save()
+
+    # Remove some keys and save
+    idx.remove([0, 1, 2])
+    idx.save()
+
+    # Verify tombstone file exists
+    tombstone_path = tmp_path / "tombstones.npy"
+    assert tombstone_path.exists()
+
+    # Delete tombstone file
+    tombstone_path.unlink()
+
+    # Reload — should not crash, tombstoned keys reappear
+    idx2 = ShardedIndex(ndim=32, path=tmp_path)
+    assert len(idx2) >= 100  # All keys including formerly tombstoned ones
+    assert idx2.contains(0)
+    assert idx2.contains(1)
+    assert idx2.contains(2)
+
+
+def test_stale_tmp_shard_cleaned_up_on_load(tmp_path):
+    """Stale .tmp files from interrupted durable_write are cleaned on load."""
+    idx = ShardedIndex(ndim=32, path=tmp_path)
+    idx.add(list(range(5)), np.random.rand(5, 32).astype(np.float32))
+    idx.save()
+
+    # Simulate interrupted durable_write leaving a .tmp file
+    stale_tmp = tmp_path / "shard_000.usearch.tmp"
+    stale_tmp.write_bytes(b"incomplete write")
+
+    # Reload — .tmp should be cleaned up
+    idx2 = ShardedIndex(ndim=32, path=tmp_path)
+    assert not stale_tmp.exists()
+    assert len(idx2) == 5
+
+
+def test_save_progress_callback_preserved(tmp_path):
+    """save(progress=callback) passes the progress callback through to buffer serialization."""
+    idx = ShardedIndex(ndim=32, path=tmp_path)
+    idx.add(list(range(5)), np.random.rand(5, 32).astype(np.float32))
+
+    progress_calls = []
+
+    def progress_cb(done: int, total: int) -> bool:
+        progress_calls.append((done, total))
+        return True
+
+    idx.save(progress=progress_cb)
+    assert len(progress_calls) > 0
+
+
+def test_no_direct_save_path_in_sharded(tmp_path):
+    """Audit: no writable shard persistence bypasses durable_write."""
+    import ast
+
+    sharded_path = Path(__file__).parent.parent / "src" / "iscc_usearch" / "sharded.py"
+    source = sharded_path.read_text()
+    tree = ast.parse(source)
+
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match pattern: <something>.save(<string_arg>) where string_arg is a str conversion
+        if not isinstance(func, ast.Attribute) or func.attr != "save":
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        # Check if the first arg is str(...) or a string literal — a path argument
+        if isinstance(first_arg, ast.Call) and isinstance(first_arg.func, ast.Name) and first_arg.func.id == "str":
+            violations.append(node.lineno)
+        elif isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+            violations.append(node.lineno)
+
+    assert violations == [], f"Direct .save(path) calls found at lines: {violations}"
+
+
+def test_bloom_not_rebuilt_when_disabled(tmp_path):
+    """When bloom_filter=False, missing bloom file doesn't trigger rebuild."""
+    idx = ShardedIndex(ndim=32, path=tmp_path, bloom_filter=False)
+    idx.add(list(range(5)), np.random.rand(5, 32).astype(np.float32))
+    idx.save()
+
+    idx2 = ShardedIndex(ndim=32, path=tmp_path, bloom_filter=False)
+    assert idx2._bloom is None
+    assert idx2.contains(0)
+
+
+def test_tombstone_removal_safe_across_crash(tmp_path):
+    """Tombstones are persisted after shard, so removed tombstones can't expose stale keys."""
+    idx = ShardedIndex(ndim=32, path=tmp_path, shard_size=500)
+
+    # Build enough data to have view shards
+    for i in range(100):
+        idx.add(i, np.random.rand(32).astype(np.float32))
+    idx.save()
+
+    # Remove key 0 (tombstone it) and persist the tombstone to disk
+    idx.remove(0)
+    idx.save()
+    assert not idx.contains(0)
+
+    # Re-add key 0 — clears tombstone in memory, adds to active shard
+    idx.add(0, np.random.rand(32).astype(np.float32))
+    assert idx.contains(0)
+
+    # Simulate crash during save: shard write fails
+    def crash_on_shard(data, target):
+        if str(target).endswith(".usearch"):
+            raise OSError("Simulated crash")
+
+    with patch("iscc_usearch.sharded.durable_write", side_effect=crash_on_shard):
+        with pytest.raises(OSError):
+            idx.save()
+
+    # Because tombstones are persisted AFTER shards, the crash prevents the
+    # tombstone removal from reaching disk. On reload, key 0 stays tombstoned.
+    idx2 = ShardedIndex(ndim=32, path=tmp_path)
+    assert not idx2.contains(0), "Tombstoned key must not reappear after failed shard write"


### PR DESCRIPTION
## Summary

Closes #26

- Replace all direct `Index.save(path)` calls in `ShardedIndex` with buffer serialization + `durable_write` (temp file, fdatasync, atomic `os.replace`). Affects `save()`, `_rotate_shard()`, and `compact()`.
- Enforce **bloom → shard → tombstones** persistence ordering so that tombstone removals only become visible after the shard data they depend on is durable. This prevents previously deleted keys from reappearing after a crash during shard writes.
- Add automatic bloom filter rebuild on load when the bloom file is missing or corrupt, with exception handling in `_load_bloom_if_exists`.
- Extract `_persist_bloom()` and `_persist_tombstones()` helpers to eliminate duplicated save logic.

## Test plan

- [x] `test_save_uses_durable_write` — monkeypatches `durable_write` to verify it's called for save
- [x] `test_rotation_uses_durable_write` — verifies rotation goes through `durable_write`
- [x] `test_compact_uses_durable_write` — verifies compact goes through `durable_write`
- [x] `test_original_shard_intact_on_durable_write_failure` — original file untouched when write fails
- [x] `test_rotation_persistence_order` — bloom < shard < tombstones ordering verified
- [x] `test_tombstone_removal_safe_across_crash` — deleted key stays deleted after failed shard write
- [x] `test_bloom_rebuild_on_corrupt_file` — corrupt bloom triggers rebuild
- [x] `test_bloom_missing_file_rebuilds_on_load` — missing bloom triggers rebuild
- [x] `test_tombstone_file_missing_on_reload` — no crash, keys reappear as expected
- [x] `test_no_direct_save_path_in_sharded` — AST audit: no `.save(str(...))` calls remain
- [x] `test_save_progress_callback_preserved` — progress callback passes through to buffer serialization
- [x] Full test suite: 985 passed, 100% coverage